### PR TITLE
Add `tag` prop

### DIFF
--- a/docs/vue2InteractDraggable/README.md
+++ b/docs/vue2InteractDraggable/README.md
@@ -37,7 +37,7 @@ export default {
 [Sandbox demo](https://codesandbox.io/s/n34kv9n2wp)
 
 ## Event bus usage
-Using event bus allows us to fire the `Vue2InteractDraggable` component methods from the outside of the component. 
+Using event bus allows us to fire the `Vue2InteractDraggable` component methods from the outside of the component.
 
 The component accepts `interact-event-bus-events` property tells `Vue2InteractDraggable` component to listen to those events and fire appropriate method when needed.
 
@@ -195,3 +195,10 @@ Vertical (Y) distance to which the element will be moved when vertical (Y) thres
 - default: {}
 
 Allows to fire the `Vue2InteractDraggable` component methods from the outside of the component.
+
+### tag
+
+- type: String
+- default: 'div'
+
+Defines the root element of the `Vue2InteractDraggable` component.

--- a/src/components/Vue2InteractDraggable.vue
+++ b/src/components/Vue2InteractDraggable.vue
@@ -1,6 +1,7 @@
 <template>
-  <div
+  <component
     ref="interactElement"
+    :is="tag"
     :class="{ 'vue-interact-animated': interactIsAnimating }"
     :style="{
       transform: interactTransformString,
@@ -8,7 +9,7 @@
     }"
   >
     <slot />
-  </div>
+  </component>
 </template>
 
 <script>
@@ -83,6 +84,10 @@ export default {
       type: Number,
       default: 300,
     },
+    tag: {
+      type: String,
+      default: 'div'
+    }
   },
 
   data() {


### PR DESCRIPTION
This adds a `tag` prop, defaulting to `div`, that allows the `Vue2IneractDraggable` component to be used in different semantic contexts, such as a list item or a table row.